### PR TITLE
Add support for environment variables, closes #3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.10-alpine
 
 COPY . /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -12,15 +12,24 @@ docker-image available [Docker Hub](https://hub.docker.com/r/raphii/synology_bac
 3. wait for image download to finish
 4. launch image
 5. set config.json as filevolume to /app/config.json
-6. add port settings
+6. add port settings (The default exporter-port is 9771)
 7. ???
 8. scrape metrics :)
 
 
 ### Configure
-change the settings in config.json to your needs
 
-The default exporter-port is 9771.
+#### Configure with just a config file
+Copy `config.json.dist` to `config.json` then change the settings in `config.json` to your needs
+
+#### Configure with just Environment Variables
+Look in the `config.json.dist` file, then simply uppercase the keys and provide the values, for example:
+* `DSMAddress` becomes `DSMADDRESS`
+* `Cert_Verify` becomes `CERT_VERIFY`
+* etc
+
+#### Configure with both the config file and Environment Variables
+Copy `config.json.dist` to `config.json` then change the settings in `config.json` to your needs. Remove any lines that are not wanted in the config file, for example if having a password in the config file is not desired, remove that line, then provide the environment variable `PASSWORD`. If a value is provided in the config file and as an environment variable, the config file will take precedence. Note: JSON files should not have a `,` on the last configuration line, if the last line has a comma this exporter will not work
 
 
 ### Metrics


### PR DESCRIPTION
# general notes
Here is the PR that should close #3. A few changes I made:
* Bumped to Python 3.10, so the new `match` and `case` could be used
* moved the opening and reading of the config file to the `__main__` portion of the code
* my editor automatically removes extraneous whitespace, so there are a few places where whitespace is removed
* this is commented in the code, but casting a string to a bool via `distutils.util.strtobool` is deprecated and will be removed in Python 3.12, so instead of kicking the can down the road I just addressed it here by making a new function called `convert_to_bool`
* I'm not a python programmer, or even really a programmer at all, so if there are pythonisms or other efficiencies I am not doing, let me know and I can try to fix them
* since I am not running this on a Synology, I could use some guidance in the README on how environment variables might be used there
* hopefully everything is relatively self-explanatory

# test cases
I tried to break it in a few ways, I think it's decently resilient at this point. Here are some of the test cases I ran to ensure it was properly functioning:

* no config.json, no environment variables: quits properly with an good error and an `exit(1)`
```shell
$ cat config.json
cat: can't open 'config.json': No such file or directory
$ python init.py
Configuration item 'DSMAddress' wasn't found in config.json, attempting to read from environnment variable 'DSMADDRESS'
Configuration item 'DSMPort' wasn't found in config.json, attempting to read from environnment variable 'DSMPORT'
Configuration item 'Username' wasn't found in config.json, attempting to read from environnment variable 'USERNAME'
Configuration item 'Password' wasn't found in config.json, attempting to read from environnment variable 'PASSWORD'
Configuration item 'Secure' wasn't found in config.json, attempting to read from environnment variable 'SECURE'
Configuration item 'Cert_Verify' wasn't found in config.json, attempting to read from environnment variable 'CERT_VERIFY'
Configuration item 'ActiveBackup' wasn't found in config.json, attempting to read from environnment variable 'ACTIVEBACKUP'
Configuration item 'HyperBackup' wasn't found in config.json, attempting to read from environnment variable 'HYPERBACKUP'
Configuration item 'HyperBackupVault' wasn't found in config.json, attempting to read from environnment variable 'HYPERBACKUPVAULT'
Configuration item 'ExporterPort' wasn't found in config.json, attempting to read from environnment variable 'EXPORTERPORT'
Configuration item 'DSM_Version' wasn't found in config.json, attempting to read from environnment variable 'DSM_VERSION'
ERROR - Missing or bad configuration for ['DSMAddress', 'DSMPort', 'Username', 'Password', 'Secure', 'Cert_Verify', 'ActiveBackup', 'HyperBackup', 'HyperBackupVault', 'ExporterPort', 'DSM_Version'], it couldn't be found in config.json or in any environment variables, exiting
$ echo $?
1
```

* no config.json, but all env vars are specified: works as expected
```shell
$ cat config.json
cat: can't open 'config.json': No such file or directory
$ DSMADDRESS=syno.ip.add.ress DSMPORT=5001 USERNAME=user PASSWORD='password' SECURE=true CERT_VERIFY=false ACTIVEBACKUP=false HYPERBACKUP=true HYPERBACKUPVAULT=false EXPORTERPORT
=9771 DSM_VERSION=6 python init.py
Synology Backup Exporter
2022 - raphii / Raphael Pertl
You are now logged in!
INFO - Web Server running on Port 9771
```

* all config in config.json, no env vars: works as expected
```shell
$ cat config.json
{
    "DSMAddress": "syno.ip.add.ress",
    "DSMPort": "5001",
    "Username": "user",
    "Password": "password",
    "Secure": true,
    "Cert_Verify": false,
    "ActiveBackup": false,
    "HyperBackupVault": false,
    "HyperBackup": true,
    "ExporterPort": "9771",
    "DSM_Version": 6
}
$ python init.py
Synology Backup Exporter
2022 - raphii / Raphael Pertl
You are now logged in!
INFO - Web Server running on Port 9771
```

* some in config.json, some from env vars. This is also a good example of the type casting, since environment variables are always brought in as strings, I needed to cast them to `int`s or `bool`s, this showcases that both of those functions work (I added a `print()` statement to show off the `config` dict for this example, notice that 'yes' and 'no' are also translated to their proper bool): works as expected
```shell
$ cat config.json
{
    "DSMAddress": "syno.ip.add.ress",
    "DSMPort": "5001",
    "Username": "user",
    "Cert_Verify": false,
    "ActiveBackup": false,
    "HyperBackupVault": false,
    "ExporterPort": "9771"
}
$ PASSWORD='password' SECURE=true HYPERBACKUP=yes ACTIVEBACKUP=false HYPERBACKUPVAULT=no DSM_VERSION=6 python init.py
VERBOSE DICT - {'DSMAddress': 'syno.ip.add.ress', 'DSMPort': '5001', 'Username': 'user', 'Cert_Verify': False, 'ActiveBackup': False, 'HyperBackupVault': False, 'ExporterPort': '9771', 'Password': 'password', 'Secure': True, 'HyperBackup': True, 'DSM_Version': '6'} # this is not in the normal output, just showing off the dict
Synology Backup Exporter
2022 - raphii / Raphael Pertl
You are now logged in!
INFO - Web Server running on Port 9771
```

* some in config.json, some from env vars, except the env vars have bad values (bad values are shown as `None` in the dict): quits properly with an good error and an exit(1)
```shell
cat config.json
{
    "DSMAddress": "syno.ip.add.ress",
    "DSMPort": "5001",
    "Username": "user",
    "Cert_Verify": false,
    "ActiveBackup": false,
    "HyperBackupVault": false,
    "ExporterPort": "9771"
}
PASSWORD='password' SECURE=true HYPERBACKUP=2 ACTIVEBACKUP=false HYPERBACKUPVAULT=no DSM_VERSION=no python init.py
Configuration item 'Password' wasn't found in config.json, attempting to read from environnment variable 'PASSWORD'
Configuration item 'Secure' wasn't found in config.json, attempting to read from environnment variable 'SECURE'
Configuration item 'HyperBackup' wasn't found in config.json, attempting to read from environnment variable 'HYPERBACKUP'
Configuration item 'DSM_Version' wasn't found in config.json, attempting to read from environnment variable 'DSM_VERSION'
VERBOSE DICT - {'DSMAddress': 'syno.ip.add.ress', 'DSMPort': '5001', 'Username': 'user', 'Cert_Verify': False, 'ActiveBackup': False, 'HyperBackupVault': False, 'ExporterPort': '9771', 'Password': 'password', 'Secure': True, 'HyperBackup': False, 'DSM_Version': None} # this is not in the normal output, just showing off the dict
ERROR - Missing or bad configuration for ['DSM_Version'], it couldn't be found in config.json or in any environment variables, exiting
$ echo $?
1
```

One thing to note: If the `config.json` has bad values, it will continue as normal but could blow up later. I saw this as out of scope since that was true of the code before I made any changes, I didn't try to address that problem.

This was fun! Thanks for responding to my issue and letting me work on this!