### PR TITLE
Fix exporter if a backup has never completed, closes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ synology_hyper_backup_lastbackup_successful_timestamp
 synology_hyper_backup_lastbackup_timestamp
 synology_hyper_backup_lastbackup_duration
 ```
+**Note**: For the first time a Hyper Backup is run, the exporter will report the backup job as being successful with a duration of 0 seconds, and completion timestamps of whenever the exporter scraped the Synology.
 
 #### Hyper Backup Vault
 Hyper Backup Vault metrics have these labels:

--- a/init.py
+++ b/init.py
@@ -114,10 +114,19 @@ def hyper_backup_get_info():
         hyper_backup_task = hyper_backup_taskname[result] #taskname
         hyper_backup_last_success = hyper_backup_taskresult['data']['last_bkp_success_time'] #last success
 
+        if hyper_backup_last_success=='': # if the backup has never completed, set the time to now
+            hyper_backup_last_success = datetime.datetime.now().strftime("%Y/%m/%d %H:%M")
+
         hyper_backup_last_success_timestamp = time.mktime(time.strptime(hyper_backup_last_success, "%Y/%m/%d %H:%M"))
 
         hyper_backup_start_time = hyper_backup_taskresult['data']['last_bkp_time']
         hyper_backup_end_time = hyper_backup_taskresult['data']['last_bkp_end_time']
+
+        if hyper_backup_start_time=='': # if the backup has never completed, set the time to now
+            hyper_backup_start_time = datetime.datetime.now().strftime("%Y/%m/%d %H:%M")
+
+        if hyper_backup_end_time=='': # if the backup has never completed, set the time to now
+            hyper_backup_end_time = datetime.datetime.now().strftime("%Y/%m/%d %H:%M")
 
         hyper_backup_start_timestamp = time.mktime(time.strptime(hyper_backup_start_time, "%Y/%m/%d %H:%M"))
         hyper_backup_end_timestamp = time.mktime(time.strptime(hyper_backup_end_time, "%Y/%m/%d %H:%M"))


### PR DESCRIPTION
Hello again @raph2i! Here's a PR that should close #2 

I ran into the issue you documented in #2 where if a backup hadn't completed yet, the exporter blew up. I wasn't sure how you wanted to solve it, so I just set all the empty dates/times to datetime.now

That means the exporter will report
* the last successful timestamp as constantly moving, until the job is finished
* the start time of the last backup as constantly moving, until the job is finished
* the length of the last backup as ~0

If that's not how you'd approach it (ie you'd rather use a try/except and skip the job or something) then let me know and I can adjust! 
I thought this was better than just skipping the job completely, and didn't want to set off alarms for having old or broken backups when the reality is: the backup just hadn't completed its first run yet