### PR TITLE
scrape on scrape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 config.json
+.idea/
+__pycache__/


### PR DESCRIPTION
I was reading the code because I encountered a crash (trying to scrape hyperbackup vault eventhough I didn't have that package installed) and found that the scraping from the backup was constant, in the background, polling the api. Prometheus is already scraping the exporter every X minutes/seconds as configured by the monitoring user, there is no need to continuously scrape the api in excess of that, many scrapes between  two scrapes of prometheus are done for nothing. We can scrape the synology api on-demand, when asked by prometheus, using a custom collector, instead of using the "request timer" as in the prometheus examples https://prometheus.github.io/client_python/getting-started/three-step-demo/.
